### PR TITLE
Move autoland service ports to avoid port conflict with Docker CE

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -208,7 +208,7 @@ services:
     image: mozilla/autolandhg:latest
     restart: always
     ports:
-      - "8101:8000"
+      - "8201:8000"
     volumes:
       - autoland-hg:/repos
     depends_on:
@@ -248,7 +248,7 @@ services:
       - autoland.db
       - autoland.transplant-init
     ports:
-      - "8100:8000"
+      - "8200:8000"
     links:
       - autoland.db:autolanddb
       - autoland.hg:autolandhg


### PR DESCRIPTION
Docker CE v19.03 includes a docker-proxy server. That server takes
host port 8101, blocking the autoland.hg container from starting. This
patch moves the autoland.* ports up-range a bit so the service starts
again.