### PR TITLE
No bug - Adds HTTP_ALLOWED to local-dev shell

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -280,6 +280,8 @@ services:
     build:
       context: docker/local-dev
       dockerfile: ./Dockerfile
+    environment:
+      HTTP_ALLOWED: 1
     volumes:
       - .:/home/phab/repo:ro
     depends_on:


### PR DESCRIPTION
We don't set up HTTPS in our development environment, but moz-phab wants to be secure and throws an error if it
connects insecurely to a Phabricator instance. However, for local development, it's worth overriding this warning
with HTTP_ALLOWED=1