### PR TITLE
No bug - move common local-dev environment setup to init-file

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,20 +96,12 @@ $ docker-compose down
 The "local-dev" container includes command-line tools used to interact
 with Conduit services.
 
-To set up the container,
-
- 1. `$ docker-compose run local-dev`. A shell will open.
- 1. `$ ./clone_repositories.sh`. Repositories will be cloned from
-    http://hg.test/
- 1. The Mercurial repository is placed in the `./test-repo/`.
- 1. `source $VIRTUAL_ENV/bin/activate` to get `moz-phab` on your `PATH`
- 1. Run `moz-phab install-certificate` to authenticate yourself in the local-dev
-    environment.  Choose one of the [Preconfigured Users](#preconfigured-users)
-    (preferably the `conduit` one)
- 1. Use as a normal local development repository.
+To set up the container run `docker-compose run local-dev`.
+You will be placed inside of a repository cloned from http://hg.test. You can
+use it as a normal local development repository.
 
 **Note**: A `git-cinnabar` version of the same repository is located at
-`./test-repo-cinnabar/`. The forked version of Arcanist is also
+`~/test-repo-cinnabar/`. The forked version of Arcanist is also
 provided and aliased as the `cinnabarc`.
 
 ## Accessing the websites provided by the suite

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -273,7 +273,7 @@ services:
   # LOCAL-DEV
   # Provide an ability to run all CLI developer needs:
   # * CVS push/pull to autoland.hg
-  # * arc diff to phabricator.test
+  # * moz-phab to phabricator.test
   ###########################
 
   local-dev:
@@ -283,7 +283,7 @@ services:
     environment:
       HTTP_ALLOWED: 1
     volumes:
-      - .:/home/phab/repo:ro
+      - local-dev:/home/phab
     depends_on:
       - tinyproxy
       - phabricator.test
@@ -360,6 +360,7 @@ volumes:
   phabricator-app:
   phabricator-mysql-db:
   lando-postgres-db:
+  local-dev:
   bmo-mysql-db:
   bmo-data-dir:
   autoland-hg:

--- a/docker/local-dev/Dockerfile
+++ b/docker/local-dev/Dockerfile
@@ -70,6 +70,8 @@ COPY arcrc .arcrc
 RUN chmod 600 .arcrc
 COPY hgrc .hgrc
 COPY gitconfig .gitconfig
+COPY moz-phab-config .moz-phab-config
+COPY initfile.sh .initfile.sh
 COPY clone_repositories.sh ./
 RUN chown -R phab:phab /home/phab \
  && ln -fs /home/phab/phabricator/cinnabarc/bin/arc /usr/local/bin/cinnabarc
@@ -92,4 +94,4 @@ RUN mkdir -p phabricator \
 RUN pip3 install MozPhab \
  && echo "export PATH=$VIRTUAL_ENV/bin:/home/phab/phabricator/arcanist/bin:/home/phab/git-cinnabar:/home/phab/review:/home/phab/.local/bin:\$PATH" >> .bashrc
 
-CMD ["/bin/bash", "-l"]
+CMD ["/bin/bash", "-c", "exec bash --init-file <(cat /etc/profile ~/.bashrc .initfile.sh)"]

--- a/docker/local-dev/arcrc
+++ b/docker/local-dev/arcrc
@@ -3,8 +3,6 @@
     "phabricator.uri": "http://phabricator.test"
   },
   "hosts": {
-    "http://phabricator.test/api/": {
-      "token": "cli-wnxaaftwm34jjfheiokqevsshlg7"
-    }
+    "http://phabricator.test/api/": {}
   }
 }

--- a/docker/local-dev/initfile.sh
+++ b/docker/local-dev/initfile.sh
@@ -1,0 +1,6 @@
+# Put common repository setup in an initfile to reduce boilerplate setup.
+# Don't use a .bashrc so that, if the entrypoint needs to be skipped, you can just override CMD to be "bash" (rather
+# than having to force bash to ignore the .bashrc)
+./clone_repositories.sh
+cd test-repo || exit
+moz-phab install-certificate

--- a/docker/local-dev/initfile.sh
+++ b/docker/local-dev/initfile.sh
@@ -1,6 +1,11 @@
 # Put common repository setup in an initfile to reduce boilerplate setup.
 # Don't use a .bashrc so that, if the entrypoint needs to be skipped, you can just override CMD to be "bash" (rather
 # than having to force bash to ignore the .bashrc)
-./clone_repositories.sh
-cd test-repo || exit
-moz-phab install-certificate
+if [ -f ~/.volume-initialized ]; then
+  cd test-repo || exit
+else
+  ./clone_repositories.sh
+  cd test-repo || exit
+  moz-phab install-certificate
+  touch ~/.volume-initialized
+fi

--- a/docker/local-dev/moz-phab-config
+++ b/docker/local-dev/moz-phab-config
@@ -1,0 +1,23 @@
+[ui]
+no_ansi = False
+
+[vcs]
+safe_mode = False
+
+[git]
+remote =
+
+[submit]
+auto_submit = True
+always_blocking = False
+warn_untracked = True
+
+[patch]
+apply_to = base
+create_bookmark = True
+always_full_stack = False
+
+[updater]
+self_last_check = 1579203515
+arc_last_check = 0
+self_auto_update = True


### PR DESCRIPTION
We had documentation explaining the static steps to set up the local-dev environment every time you run it.
These static steps have been moved into a bash init file, which will automatically run and query you for a Phab API key.

Also sets a default so you aren't prompted if you want to:
> `Submit to http://phabricator.test (YES/No/Always)?`

-----

Also stores `local-dev` state in a volume.
If you exited out of local-dev and log back in, you lose your repository state, moz-phab token, and bash history.
By storing it in a volume, you keep it until you `docker-compose down -v`, which makes dev a little easier IMHO.