### PR TITLE
Bug 1611537: fix lando dev-version.json mount error

### DIFF
--- a/docker-compose.lando-api.yml
+++ b/docker-compose.lando-api.yml
@@ -11,15 +11,15 @@ services:
     image: suite_lando-api
     environment:
       PORT: 9000
-      VERSION_PATH: /version.json
+      VERSION_PATH: /config/version.json
     volumes:
       - lando-api-app-local:/app
-      - lando-api-version-local:/version.json
+      - lando-api-version-local:/config
       - lando-api-migrations-local:/migrations
   lando-ui.test:
     volumes:
       - lando-api-app-local:/app
-      - lando-api-version-local:/version.json
+      - lando-api-version-local:/config
       - lando-api-migrations-local:/migrations
 
 volumes:
@@ -33,7 +33,7 @@ volumes:
     driver: local
     driver_opts:
       type: none
-      device: '$PWD/../lando-api/docker/dev-version.json'
+      device: '$PWD/../lando-api/docker/dev-config/'
       o: bind
   lando-api-migrations-local:
     driver: local

--- a/docker-compose.lando-ui.yml
+++ b/docker-compose.lando-ui.yml
@@ -9,8 +9,6 @@ services:
       context: ../lando-ui/
       dockerfile: ./docker/Dockerfile-dev
     image: suite_lando-ui
-    environment:
-      VERSION_PATH: /version.json
     volumes:
       - lando-ui-app-local:/app/landoui
       - lando-ui-tests-local:/app/tests


### PR DESCRIPTION
docker-compose bind mounts don't support mounting files, so we put lando's version.json override in a directory