### PR TITLE
Bug 1605892: update name of renamed directory r?dkl

### DIFF
--- a/docker-compose.phabricator.yml
+++ b/docker-compose.phabricator.yml
@@ -21,5 +21,5 @@ volumes:
     driver: local
     driver_opts:
       type: none
-      device: '$PWD/../phabricator-extensions/extensions/'
+      device: '$PWD/../phabricator-extensions/moz-extensions/'
       o: bind


### PR DESCRIPTION
In the reorganization of the phabricator-extensions repository, "/extensions" was renamed to "moz-extensions".

This just updates the associated volume reference