### PR TITLE
No bug - expose phabricator db to improve debuggability

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -188,6 +188,8 @@ services:
     environment:
       - MYSQL_ROOT_PASSWORD=password
     restart: on-failure
+    ports:
+      - "3306:3306"
 
   ###############################
   # Transplant services


### PR DESCRIPTION
I'm using an external database tool (DBeaver) to look into the Phabricator database(s) to debug issues and implement features that query said databases. Having vision into the structure and data make it easier to understand what's going on under-the-hood