### PR TITLE
Bug 1659617: Support new autolandhg entry point requirements, repos

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -216,6 +216,7 @@ services:
 
   autoland.hg:
     image: mozilla/autolandhg:latest
+    command: start
     restart: always
     ports:
       - "8201:8000"

--- a/docker/local-dev/clone_repositories.sh
+++ b/docker/local-dev/clone_repositories.sh
@@ -16,5 +16,5 @@ then
   rm -rf test-repo-cinnabar
 fi
 
-hg clone http://hg.test/ test-repo
-git clone hg::http://hg.test/ test-repo-cinnabar
+hg clone http://hg.test/test-repo test-repo
+git clone hg::http://hg.test/test-repo test-repo-cinnabar


### PR DESCRIPTION
Autolandhg no longer defaults to "starting" when no specific command is provided, so it needs to be explicitly specified.
Additionally, there's now more than one repository, so clone_repositories.sh has to be more specific.