### PR TITLE
Bug 1678140: Install cargo in local-dev image so it can install MozPhab

### DIFF
--- a/docker/local-dev/Dockerfile
+++ b/docker/local-dev/Dockerfile
@@ -65,6 +65,15 @@ RUN addgroup --gid 1000 phab \
 
 WORKDIR /home/phab
 
+# Install Rust so Glean (required by MozPhab) can be installed
+USER phab
+RUN curl https://sh.rustup.rs -sSf > /tmp/rustup.sh
+RUN chmod 755 /tmp/rustup.sh
+RUN /tmp/rustup.sh -y
+RUN rm /tmp/rustup.sh
+ENV PATH="/home/phab/.cargo/bin:$PATH"
+USER root
+
 # copy configuration
 COPY arcrc .arcrc
 RUN chmod 600 .arcrc


### PR DESCRIPTION
MozPhab depends on Glean, and when a Glean wheel isn't available, it
needs Rust to build.