### PR TITLE
Bug 1701101: Upgrade pip so it understands manylinux2014 wheels

### DIFF
--- a/docker/local-dev/Dockerfile
+++ b/docker/local-dev/Dockerfile
@@ -43,6 +43,10 @@ RUN apt-get install -y \
         python3-dev \
         vim
 
+# Upgrade pip to be compatible with new platform tag formats
+RUN pip install --upgrade pip
+RUN pip3 install --upgrade pip
+
 RUN pip install virtualenv \
  && pip3 install virtualenv \
  && python3 -m virtualenv $VIRTUAL_ENV \


### PR DESCRIPTION
`glean-sdk==36.0.0` has a Linux wheel that uses the `manylinux2014`
platform tag. This tag is only supported after `pip==19.3`.

We upgrade `pip` so that it understands the new tags.