### PR TITLE
no bug - Update docker-compose.phabricator.yml to no longer treat moz-extensions as separate repo

### DIFF
--- a/docker-compose.phabricator.yml
+++ b/docker-compose.phabricator.yml
@@ -10,16 +10,3 @@ services:
       dockerfile: ./Dockerfile
       target: development
     image: suite_phabricator
-    volumes:
-      - phabricator-moz-extensions-local:/app/moz-extensions
-  phabricator.test:
-    volumes:
-      - phabricator-moz-extensions-local:/app/moz-extensions
-
-volumes:
-  phabricator-moz-extensions-local:
-    driver: local
-    driver_opts:
-      type: none
-      device: '$PWD/../phabricator/moz-extensions'
-      o: bind


### PR DESCRIPTION
In the olden days, we used to have a fork of upstream phabricator and a separate repo with just our code in moz-extensions. We later merged moz-extensions into our own copy of phabricator so it all resides now at mozilla-conduit/phabricator.