### PR TITLE
static_files: clear `STATIC_ROOT` on `collectstatic` call (bug 1903648)

### DIFF
--- a/docker-compose.lando.yml
+++ b/docker-compose.lando.yml
@@ -9,7 +9,7 @@ services:
     tty: true
     command: bash -c "
       lando migrate &&
-      lando collectstatic --no-input &&
+      lando collectstatic --clear --no-input &&
       lando runserver 0.0.0.0:80"
     env_file:
       - ../lando/.env


### PR DESCRIPTION
The `--clear` argument will ensure all stale static files are deleted.