### PR TITLE
docker_compose: Call `generate_version_file` when building `lando` (bug 1867133)

### DIFF
--- a/docker-compose.lando.yml
+++ b/docker-compose.lando.yml
@@ -8,6 +8,7 @@ services:
     stdin_open: true
     tty: true
     command: bash -c "
+      lando generate_version_file &&
       lando migrate &&
       lando collectstatic --no-input &&
       lando runserver 0.0.0.0:80"


### PR DESCRIPTION
This is just making the docker-compose `suite` build in sync with the `lando` build.

https://github.com/mozilla-conduit/lando/blob/main/compose.yaml#L23