### PR TITLE
docker-compose: don't export internal ports (bug 1935046)

### DIFF
--- a/docker-compose.autolandhg.yml
+++ b/docker-compose.autolandhg.yml
@@ -23,9 +23,6 @@ services:
     environment:
       SSHD_PORT: "8022"
       SSH_PUBLIC_KEY: "ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBHWpDYI3qzSxV8tbjH8C4z3ef6QU2yBKGTHTFf6OrPrqDIO++ixfr4LW3yGmW4Q3CRJcx8KZ6hnx2FPnDOCsrqw= app"
-    ports:
-      - "8000:8000"
-      - "8022:8022"
     volumes:
       - autoland.hg:/repos
       - autoland.ssh:/home/app/.ssh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -181,8 +181,6 @@ services:
       POSTGRES_USER: postgres
     volumes:
       - lando-postgres-db:/var/lib/postgresql/data
-    ports:
-      - "54322:5432"
 
   lando-api.landing-worker:
     platform: linux/x86_64
@@ -255,8 +253,6 @@ services:
       timeout: 120s
       retries: 13
     restart: on-failure
-    ports:
-      - "3306:3306"
 
   ###############################
   # Transplant services
@@ -284,8 +280,6 @@ services:
     restart: always
     environment:
       SSH_PUBLIC_KEY: "ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBHWpDYI3qzSxV8tbjH8C4z3ef6QU2yBKGTHTFf6OrPrqDIO++ixfr4LW3yGmW4Q3CRJcx8KZ6hnx2FPnDOCsrqw="
-    ports:
-      - "8201:8000"
     volumes:
       - autoland-hg:/repos
     depends_on:


### PR DESCRIPTION
…5046)

The `ports` directive exposes the specified service's port on the local
host. Most of the ports in the suite stack only need to be reachable
within the stack, with only the tinyproxy port exposed more widely.
    
Removing this prevents port collision when running multiple stacks using
common ports (e.g., 80, 5432, ...).