### PR TITLE
lando: add LANDO_CACHE_REDIS env (bug 1994567)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -182,6 +182,7 @@ services:
       PHABRICATOR_URL: http://phabricator.test
       PHABRICATOR_UNPRIVILEGED_API_KEY: api-qdaethogwpld3wmn2cnhbh57wkux
       TREESTATUS_URL: https://treestatus.mozilla-releng.net
+      LANDO_CACHE_REDIS: redis://lando.redis:6379
       # DATA_UPLOAD_MAX_MEMORY_SIZE: 10
     env_file: ../lando/.env
     command: bash -c "


### PR DESCRIPTION
This is useful to inspect the cache in local environment.

In remote environment, we haven't found it necessary to use something else than in-memory caching.