### PR TITLE
docker-compose: remote environment-related fixes and doc

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -258,7 +258,7 @@ services:
 
   lando.db:
     platform: linux/amd64
-    image: postgres
+    image: postgres:17
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -174,11 +174,21 @@ services:
     stdin_open: true
     tty: true
     environment: &lando-env
+      # To simulate a remote environment, uncomment the following lines...
+      # ENVIRONMENT: development
+      # DJANGO_SETTINGS_MODULE: lando.remote_settings
+
+      # ... and comment this one.
+      ENVIRONMENT: local
+      #
+      # This will likely trigger errors when running the `setup_dev` and
+      # `collectstatic` commands below. They need to be manually disabled
+      # during such a simulation.
+
       <<: *pulse_env
       DJANGO_LOG_LEVEL: debug
       LOG_LEVEL: INFO
       DEFAULT_DB_HOST: lando.db
-      ENVIRONMENT: local
       PHABRICATOR_URL: http://phabricator.test
       PHABRICATOR_UNPRIVILEGED_API_KEY: api-qdaethogwpld3wmn2cnhbh57wkux
       TREESTATUS_URL: https://treestatus.mozilla-releng.net


### PR DESCRIPTION
 * docker-compose: pin lando.db to postgres:17
   This is what's currently running in remote environments.
 * docker-compose: add comments to document how to simulate remote environments