### PR TITLE
Suite fixes (lando version generation & postgres pinning)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -257,7 +257,7 @@ services:
 
   lando.db:
     platform: linux/amd64
-    image: postgres
+    image: postgres:17
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -190,7 +190,7 @@ services:
       #  ...
     env_file: ../lando/.env
     command: bash -c "
-      echo "version=0" > src/lando/version.py &&
+      lando migrate &&
       lando collectstatic --clear --no-input &&
       lando setup_dev &&
       lando runserver 0.0.0.0:80"
@@ -209,6 +209,7 @@ services:
       - ../lando:/code
       - ../lando/staticfiles:/code/staticfiles
       - ../lando-prorotype/media:/mediafiles
+      - /code/src/lando/version
     healthcheck:
       test: ["CMD", "curl", "-sfko/dev/null", "http://localhost/__heartbeat__"]
       interval: 10s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -191,7 +191,6 @@ services:
     env_file: ../lando/.env
     command: bash -c "
       echo "version=0" > src/lando/version.py &&
-      lando generate_version_file &&
       lando collectstatic --clear --no-input &&
       lando setup_dev &&
       lando runserver 0.0.0.0:80"


### PR DESCRIPTION
 * lando: remove generate_version_file (bug 2018645)
 * docker-compose: pin lando.db to postgres:17
 * docker: do not generate version file (bug 2018645)