### PR TITLE
docker: add support for try-like repository (bug 1986575)

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,10 @@ the normal name of command and argument list, and work by simply prefixing
 them with `./suite`. Under the hood, the script should select the most
 appropriate container to run the selected command in.
 
+Available shortcuts:
+* lando
+* local-dev
+
 ## Accessing the websites provided by the suite
 
 ### Firefox configuration

--- a/README.md
+++ b/README.md
@@ -96,7 +96,6 @@ added to the `docker-compose.override.yml` file. This file is listed in the
 
 The `./suite` script transparently apply the overrides if the file is present.
 
-
 ### In-container command shortcuts
 
 There are shortcuts for running common commands in the appropriate container,
@@ -118,6 +117,24 @@ appropriate container to run the selected command in.
 Available shortcuts:
 * lando
 * local-dev
+
+
+### Optional services
+
+Some services are disabled by default. This is generally because they are heavy
+to start and/or run, and not always necessary in a basic environment.
+
+Those services can be started as [docker compose profiles](https://docs.docker.com/compose/how-tos/profiles/),
+
+```shell
+$ ./suite --profile <PROFILE> up [...]
+```
+
+The `--profile` option can be repeated on a single command as many times for
+different profiles.
+
+The following optional profiles currently exist:
+ - `try`: clones mozilla-unified twice, in hg.test and in the try worker.
 
 ## Accessing the websites provided by the suite
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,25 @@ added to the `docker-compose.override.yml` file. This file is listed in the
 
 The `./suite` script transparently apply the overrides if the file is present.
 
+
+### In-container command shortcuts
+
+There are shortcuts for running common commands in the appropriate container,
+e.g.,
+
+```shell
+./suite lando [DJANGO-COMMAND]
+```
+
+will run any Django command accepted by the `lando` script in the `lando`
+container. One exception is the `dbshell` command, which will be emulated by
+running in the `lando.db` container instead.
+
+HINT: As a rule of thumb when adding more commands in this ilk, they should take
+the normal name of command and argument list, and work by simply prefixing
+them with `./suite`. Under the hood, the script should select the most
+appropriate container to run the selected command in.
+
 ## Accessing the websites provided by the suite
 
 ### Firefox configuration

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -234,6 +234,8 @@ services:
     command: lando start_landing_worker hg
     volumes:
       - ../lando:/code
+      # Keep those in a persistent volume, as the firefox-try repo takes a while to clone.
+      - lando-try-worker-repos:/files/repos
     restart: on-failure
     depends_on:
       lando:
@@ -353,6 +355,21 @@ services:
     volumes:
       - autoland-hg:/repos
 
+  autoland.hg-init-try:
+    platform: linux/amd64
+    image: mozilla/autolandhg:latest
+    build:
+      context: ../conduit-autoland-hg
+      dockerfile: ./Dockerfile
+    profiles:
+     # It takes a while to clone m-u, when it's not always needed.
+     # This service only starts when `--profile try` is passed.
+     - try
+    entrypoint: hg
+    command: clone https://hg.mozilla.org/mozilla-unified /repos/firefox-try
+    volumes:
+      - autoland-hg:/repos
+
   autoland.hg:
     platform: linux/amd64
     image: mozilla/autolandhg:latest
@@ -366,7 +383,14 @@ services:
     volumes:
       - autoland-hg:/repos
     depends_on:
-      - autoland.hg-init
+      autoland.hg-init:
+        condition: service_completed_successfully
+      autoland.hg-init-try:
+        condition: service_completed_successfully
+        # This service is only available when the stack is started with `--profile try`.
+        # We just let the service start if this dependency is missing.
+        required: false
+
 
   ###############################
   # Phabricator-Emails
@@ -463,6 +487,9 @@ services:
     volumes:
       - local-dev:/home/phab
       - ../review:/home/phab/review
+      # Mount some external sources for Try tests
+      # - ~/.mozbuild/lando.toml:/root/.mozbuild/lando.toml
+      # - ~/work/firefox/:/firefox/
     depends_on:
       - tinyproxy
       - phabricator.test
@@ -569,6 +596,7 @@ volumes:
   git-repos:
   git_hg_sync_clones:
   lando-postgres-db:
+  lando-try-worker-repos:
   local-dev:
   media:
   phabricator-emails-postgres-db:

--- a/suite
+++ b/suite
@@ -1,9 +1,35 @@
 #!/bin/sh
 # A simple wrapper that takes care of using compose overrides if present.
 
+while :; do
+	case $1 in
+		lando)
+			shift
+			case $1 in
+				dbshell)
+					shift
+					# Fake the DB shell command by running in the correct container
+					set - exec -it lando.db psql -U postgres "${@}"
+					;;
+				*)
+					if docker compose ps -q lando >/dev/null 2>&1; then
+						set - exec -it lando lando "${@}"
+					else
+						set - run --rm -it lando lando "${@}"
+					fi
+					;;
+			esac
+			;;
+		*)
+			break
+			;;
+	esac
+done
+
 if [ -e docker-compose.override.yml ]; then
   set - -f docker-compose.override.yml "${@}"
 fi
 set - compose -f docker-compose.yml "${@}"
 
+echo "docker ${@}" >&2
 docker "${@}"

--- a/suite
+++ b/suite
@@ -20,6 +20,11 @@ while :; do
 					;;
 			esac
 			;;
+
+		local-dev)
+			set - run --rm -it local-dev "${@}"
+			;;
+
 		*)
 			break
 			;;


### PR DESCRIPTION
As Try is a rather large repo, it's not always desirable to use it. Instead, the feature is set behind a docker compose profile which is not enabled by default, but can be on demand.