### PR TITLE
suite: add subcommands

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @mozilla-conduit/conduit-core

--- a/README.md
+++ b/README.md
@@ -88,6 +88,13 @@ their dependencies.
 ./suite up phabricator.test lando.test
 ```
 
+A shell in a specific container can be obtained with the `sbash` or `sh` subcommands, depending on what's available in the container.
+
+```shell
+./suite lando bash
+./suite phabricator sh
+```
+
 ### Compose overrides
 
 If temporary local changes to the compose stack are needed, overrides can be

--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ The following optional profiles currently exist:
    `firefox-proxy $(docker-machine ip)` if you are using `docker-machine`.
 3. A new browser with an empty profile will open.
 
+The `firefox-proxy` can also be started with `./suite firefox`.
+
 ### Websites provided by the suite
 
 - Bugzilla - http://bmo.test

--- a/docker/local-dev/Dockerfile
+++ b/docker/local-dev/Dockerfile
@@ -8,11 +8,17 @@ RUN apt-get update \
  && apt-get install -y \
         bash \
         build-essential \
+        findutils \
         ca-certificates \
         curl \
         git \
+        gzip \
         iputils-ping \
         less \
+        make \
+        perl \
+        tar \
+        unzip \
         vim \
         && rm -rf /var/lib/apt/lists/*
 

--- a/docker/local-dev/initfile.sh
+++ b/docker/local-dev/initfile.sh
@@ -7,4 +7,8 @@ else
   echo "Initializing repos..."
   ./clone_repositories.sh
   touch ~/.volume-initialized
+
+  if [ -d /firefox ]; then
+    git config --global --add safe.directory /firefox
+  fi
 fi

--- a/suite
+++ b/suite
@@ -5,7 +5,7 @@ while :; do
 	case $1 in
     firefox*)
       shift
-      exec nohup ./firefox-proxy ${*} &
+      exec nohup ./firefox-proxy "${@}" &
       exit 0
       ;;
 		lando)
@@ -38,6 +38,19 @@ while :; do
 			;;
 
 		*)
+			case $2 in
+        bash|sh)
+          CONTAINER=${1}
+          SHELL=${2}
+          shift
+          shift
+					if docker compose ps -q $1 >/dev/null 2>&1; then
+						set - exec -it "${CONTAINER}" "${SHELL}" "${@}"
+					else
+						set - run --rm -it "${CONTAINER}" "${SHELL}" "${@}"
+					fi
+        ;;
+      esac
 			break
 			;;
 	esac

--- a/suite
+++ b/suite
@@ -3,9 +3,21 @@
 
 while :; do
 	case $1 in
+    firefox*)
+      shift
+      exec nohup ./firefox-proxy ${*} &
+      exit 0
+      ;;
 		lando)
 			shift
 			case $1 in
+				bash)
+					if docker compose ps -q lando >/dev/null 2>&1; then
+						set - exec -it lando bash
+					else
+						set - run --rm -it lando bash
+					fi
+					;;
 				dbshell)
 					shift
 					# Fake the DB shell command by running in the correct container


### PR DESCRIPTION
Add `firefox` command and `bash`/`sh` subcommand to `./suite`.

The former starts the firefox-proxy without hogging the terminal. The latter allows to start a shell in the desired container.

Also, make local-dev more turnkey for working on the real Fx codebase, and add CODEOWNERS.