### PR TITLE
docker-compose: drop external Treestatus config (bug 2062491)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -180,7 +180,6 @@ services:
       ENVIRONMENT: local
       PHABRICATOR_URL: http://phabricator.test
       PHABRICATOR_UNPRIVILEGED_API_KEY: api-qdaethogwpld3wmn2cnhbh57wkux
-      TREESTATUS_URL: https://treestatus.mozilla-releng.net
       LANDO_CACHE_REDIS: redis://lando.redis:6379
       # DATA_UPLOAD_MAX_MEMORY_SIZE: 10
       #
@@ -336,11 +335,6 @@ services:
   ###############################
   # Mercurial repositories
   ###############################
-
-  autoland.treestatus:
-    platform: linux/amd64
-    image: mozilla/autolandtreestatus:latest
-    restart: always
 
   autoland.hg-init:
     platform: linux/amd64


### PR DESCRIPTION
Treestatus now lives in Lando and reads tree state from Lando's own
database, so `TREESTATUS_URL` is no longer a setting and pointing the
suite at production Treestatus does nothing. Also drop the unused
`autoland.treestatus` container, a leftover from the Transplant service
that nothing has referenced since old-Lando was removed.
